### PR TITLE
Refactor logging feature

### DIFF
--- a/core/Includes/TristLib/Core/Logging.h
+++ b/core/Includes/TristLib/Core/Logging.h
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <filesystem>
+#include <string_view>
 
 #include <plog/Log.h>
 
@@ -15,13 +16,13 @@ void InitLogging(const int logLevel, const bool simple) noexcept;
 /// Add an output to the system console
 void AddLogDestinationStdout(const bool simple, const bool colorize = true) noexcept;
 /// Add an output to syslog
-void AddLogDestinationSyslog(const int facility) noexcept;
+void AddLogDestinationSyslog(const int facility, const std::string_view ident) noexcept;
 /// Add an output to the specified file
 void AddLogDestinationFile(const std::filesystem::path &file, const size_t maxFileSize = 0,
         const size_t maxFiles = 0, const bool csv = false);
 
 /// Update the log level
-void SetLogLevel(const int logLevel) noexcept;
+void SetLogLevel(const int logLevel);
 };
 
 #endif

--- a/core/Includes/TristLib/Core/Logging.h
+++ b/core/Includes/TristLib/Core/Logging.h
@@ -2,11 +2,26 @@
 #define LOGGING_H
 
 #include <cstddef>
+#include <filesystem>
 
 #include <plog/Log.h>
 
 namespace TristLib::Core {
-void InitLogging(const int logLevel = 0, const bool simple = false) noexcept;
+/// Set up logger without any outputs
+void InitLogging(const int logLevel) noexcept;
+/// Set up logger and attach tty output
+void InitLogging(const int logLevel, const bool simple) noexcept;
+
+/// Add an output to the system console
+void AddLogDestinationStdout(const bool simple, const bool colorize = true) noexcept;
+/// Add an output to syslog
+void AddLogDestinationSyslog(const int facility) noexcept;
+/// Add an output to the specified file
+void AddLogDestinationFile(const std::filesystem::path &file, const size_t maxFileSize = 0,
+        const size_t maxFiles = 0);
+
+/// Update the log level
+void SetLogLevel(const int logLevel) noexcept;
 };
 
 #endif

--- a/core/Includes/TristLib/Core/Logging.h
+++ b/core/Includes/TristLib/Core/Logging.h
@@ -18,7 +18,7 @@ void AddLogDestinationStdout(const bool simple, const bool colorize = true) noex
 void AddLogDestinationSyslog(const int facility) noexcept;
 /// Add an output to the specified file
 void AddLogDestinationFile(const std::filesystem::path &file, const size_t maxFileSize = 0,
-        const size_t maxFiles = 0);
+        const size_t maxFiles = 0, const bool csv = false);
 
 /// Update the log level
 void SetLogLevel(const int logLevel) noexcept;

--- a/core/Sources/Logging.cpp
+++ b/core/Sources/Logging.cpp
@@ -1,7 +1,12 @@
+#include <syslog.h>
 #include <unistd.h>
 
 #include <cstring>
+#include <list>
 #include <stdexcept>
+
+// when including plog, omit macros that clash with syslog macros
+#define PLOG_OMIT_LOG_DEFINES 1
 
 #include <plog/Log.h>
 #include <plog/Appenders/ColorConsoleAppender.h>
@@ -14,49 +19,19 @@
 
 namespace TristLib::Core {
 /**
- * @brief Initialize logging
- *
- * Sets up the plog logging framework. We redirect all log output to stderr, under the assumption
- * that we'll be running under some sort of supervisor that handles capturing and storing
- * these messages.
- *
- * @param level Minimum log level to output
- * @param simple Whether the simple message output format (no timestamps) is used
+ * @brief List of all log appenders
  */
-static void InitPlog(const plog::Severity level, const bool simple) {
-    // figure out if the console is a tty
-    const bool isTty = (isatty(fileno(stdout)) == 1);
+static std::list<plog::IAppender *> gAppenders;
 
-    // set up the logger
-    if(simple) {
-        if(isTty) {
-            static plog::ColorConsoleAppender<plog::FuncMessageFormatter> ttyAppender;
-            plog::init(level, &ttyAppender);
-        } else {
-            static plog::ConsoleAppender<plog::FuncMessageFormatter> ttyAppender;
-            plog::init(level, &ttyAppender);
-        }
-    } else {
-        if(isTty) {
-            static plog::ColorConsoleAppender<plog::TxtFormatter> ttyAppender;
-            plog::init(level, &ttyAppender);
-        } else {
-            static plog::ConsoleAppender<plog::TxtFormatter> ttyAppender;
-            plog::init(level, &ttyAppender);
-        }
-    }
-}
+
 
 /**
- * @brief Initialize the logging system
+ * @brief Translate log level from integer to plog
  *
- * Set up plog. This will parse the command line specified (if non-NULL) and extract the
- * `log-level` and `log-simple` keys.
- *
- * @param level What level messages to output ([-3, 2]) where 2 is the most
- * @param simple When set, no timestamp/function name info is printed
+ * This will convert the integral log levels (centered around 0, where negative values mean less
+ * logging, and positive values more) into the associated plog level.
  */
-void InitLogging(const int level, const bool simple) noexcept {
+constexpr static inline auto TranslateLogLevel(const int level) {
     plog::Severity logLevel{plog::Severity::info};
 
     switch(std::max(std::min(level, 2), -3)) {
@@ -80,6 +55,80 @@ void InitLogging(const int level, const bool simple) noexcept {
             break;
     }
 
-    InitPlog(logLevel, simple);
+    return logLevel;
 }
+
+/**
+ * @brief Initialize logging
+ *
+ * Sets up the plog logging framework.
+ *
+ * @param level Minimum log level to output
+ */
+static void InitPlog(const plog::Severity level) {
+    plog::init(level);
+}
+
+
+
+/**
+ * @brief Initialize the logging system without any outputs
+ *
+ * @remark You _must_ call one of the `AddLogDestination` family functions to see any log messages.
+ *
+ * @param level What level messages to output ([-3, 2]) where 2 is the most
+ * @param simple When set, no timestamp/function name info is printed
+ */
+void InitLogging(const int level) noexcept {
+    InitPlog(TranslateLogLevel(level));
+}
+
+/**
+ * @brief Initialize the logging system
+ *
+ * Set up plog with a console output.
+ *
+ * @param level What level messages to output ([-3, 2]) where 2 is the most
+ * @param simple When set, no timestamp/function name info is printed
+ */
+void InitLogging(const int level, const bool simple) noexcept {
+    InitPlog(TranslateLogLevel(level));
+    AddLogDestinationStdout(simple);
+}
+
+
+
+/**
+ * @brief Install a console/stdout logger
+ *
+ * If the standard output is a terminal, we'll attempt to colorize the logs as well.
+ *
+ * @param simple Whether the simple message output format (no timestamps) is used
+ * @param colorize Apply color to messages iff stdout is a terminal
+ */
+void AddLogDestinationStdout(const bool simple, const bool colorize) noexcept {
+    plog::IAppender *appender{nullptr};
+
+    // figure out if the console is a tty
+    const bool isTty = (isatty(fileno(stdout)) == 1);
+
+    // set up the logger
+    if(simple) {
+        if(isTty && colorize) {
+            appender = new plog::ColorConsoleAppender<plog::FuncMessageFormatter>();
+        } else {
+            appender = new plog::ConsoleAppender<plog::FuncMessageFormatter>();
+        }
+    } else {
+        if(isTty && colorize) {
+            appender = new plog::ColorConsoleAppender<plog::TxtFormatter>();
+        } else {
+            appender = new plog::ConsoleAppender<plog::TxtFormatter>();
+        }
+    }
+
+    plog::get()->addAppender(appender);
+    gAppenders.push_back(appender);
+}
+
 }

--- a/core/Sources/SyslogAppender.h
+++ b/core/Sources/SyslogAppender.h
@@ -1,0 +1,61 @@
+/**
+ * @file
+ *
+ * @brief Syslog output appender
+ *
+ * Writes plog messages to syslog
+ */
+#ifndef SYSLOGAPPENDER_H
+#define SYSLOGAPPENDER_H
+
+#include <syslog.h>
+
+#define PLOG_OMIT_LOG_DEFINES 1
+#include <plog/Log.h>
+
+namespace TristLib::Core {
+/**
+ * @brief plog Appender for writing messages to syslog
+ */
+template<class Formatter>
+class SyslogAppender : public plog::IAppender {
+    private:
+        /**
+         * @brief Convert plog severity to syslog facility code
+         */
+        constexpr static inline int ConvertSeverity(const plog::Severity severity) {
+            using S = plog::Severity;
+
+            switch(severity) {
+                case S::fatal:
+                    return LOG_EMERG;
+                case S::error:
+                    return LOG_ERR;
+                case S::warning:
+                    return LOG_WARNING;
+                case S::info:
+                    return LOG_INFO;
+                case S::debug: [[fallthrough]];
+                case S::verbose:
+                    return LOG_DEBUG;
+
+                case S::none: [[fallthrough]];
+                default:
+                    return LOG_NOTICE;
+            }
+        }
+
+    public:
+        /**
+         * @brief Format message and write to syslog
+         */
+        void write(const plog::Record &record) override {
+            const auto str = Formatter::format(record);
+            const int priority = ConvertSeverity(record.getSeverity());
+
+            syslog(priority, "%s", str.c_str());
+        }
+};
+}
+
+#endif


### PR DESCRIPTION
Separates the initialization and adding of backends for the logger; existing code should continue to work with the old behavior (automatically receiving stdout log output) until modified.

This adds calls to manually add the stdout backend, as well as a file and syslog backend.